### PR TITLE
Use SVG site logo and add profile image

### DIFF
--- a/public/whit-site-logo.svg
+++ b/public/whit-site-logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" fill="currentColor">
+  <text x="0" y="30" font-size="30" font-family="sans-serif">whitcooper</text>
+</svg>

--- a/src/components/NavTimeline.astro
+++ b/src/components/NavTimeline.astro
@@ -9,7 +9,9 @@ const items = [
 ];
 ---
 <nav class="w-full flex flex-col items-center gap-3 py-6">
-  <a href="/" class="text-xl font-semibold tracking-wide">WHIT COOPER</a>
+  <a href="/" class="block">
+    <img src="/whit-site-logo.svg" alt="Whit Cooper logo" class="h-8" />
+  </a>
   <div class="relative flex items-center gap-6">
     {items.map(({href, label}) => (
       <a href={href} class="group flex flex-col items-center">

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -3,5 +3,6 @@ title: About
 headshot: /uploads/whit-prof-pic.png
 ---
 
+![Whit Cooper](https://i.imgur.com/3LwyDts.png)
 
 Hi! I'm **Whit Cooper**, a creative video editor and motion designer.


### PR DESCRIPTION
## Summary
- replace text site title with SVG logo file
- embed Imgur headshot on About page
- add site logo asset

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a1833bebc832cad0ff7bb3dbdcb40